### PR TITLE
chore(kong): add deprecation notice to kong operator

### DIFF
--- a/operators/kong/0.9.0/kong.v0.9.0.clusterserviceversion.yaml
+++ b/operators/kong/0.9.0/kong.v0.9.0.clusterserviceversion.yaml
@@ -22,6 +22,18 @@ spec:
       name: kongs.charts.konghq.com
       version: v1alpha1
   description: |
+    ## Deprecation Notice
+
+    **Use of this operator for new Kong installations is discouraged in favor of the [kubectl](https://docs.konghq.com/gateway/3.0.x/install/kubernetes/kubectl/) and [Helm](https://docs.konghq.com/gateway/3.0.x/install/kubernetes/helm-quickstart/) installation methods.
+    This operator is being deprecated in favor of a replacement based on Golang (instead of Helm).
+    During the version `v0.x.x` lifecycle of this tool we decided that Helm did not suite our needs for a robust feature-rich operator.
+    Security updates for this repository will be continued for the time being; but new features and other requests will not be prioritized.
+    You read about the successor operator [here](https://github.com/Kong/gateway-operator-docs) and we highly encourage feature requests and discussions on the new operator repository to let us know your use cases and needs.**
+
+    ---
+    
+    ## Kong Operator
+
     Kong is a popular open-source cloud-native API gateway. Kong Operator is a Kubernetes operator which manages [Kong](https://konghq.com/kong/) and [Kong Enterprise](https://konghq.com/products/kong-enterprise/) clusters.
 
     Kong Operator can deploy Kong in various configurations, for example:


### PR DESCRIPTION
This adds a deprecation notice to kong operator (which was already in place for some time now at https://github.com/Kong/kong-operator/blob/main/README.md).

One can preview the operator's page on operatorhub via https://operatorhub.io/preview.